### PR TITLE
Fixes #27 - Allow settings to be declared with explicit type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ black:
 	black tests
 
 black-ci:
-	black --check lifeguard
-	black --check tests
+	black --check --diff lifeguard
+	black --check --diff tests
 
 clean:
 	find . -iname "*.pyc" | xargs rm

--- a/lifeguard/settings.py
+++ b/lifeguard/settings.py
@@ -46,7 +46,7 @@ class SettingsManager:
                     value (object): Value to be converted
 
             Returns:
-                    value (str): the value in the specified type when type is allowed
+                    value (object): the value in the specified type when type is allowed
         """
         _format_funcs = {
             "bool": lambda x: str(x).lower() == "true",

--- a/lifeguard/settings.py
+++ b/lifeguard/settings.py
@@ -36,7 +36,6 @@ class SettingsManager(object):
         Convert setting value to explict type.
         Allowed types: int, float, str, bool.
 
-
             Parameters:
                     setting (dict): Value of the type to convert
                     value (object): Value to be converted

--- a/lifeguard/settings.py
+++ b/lifeguard/settings.py
@@ -38,7 +38,8 @@ class SettingsManager:
     def __set_type(setting, value):
         """
         Convert setting value to explict type.
-        Allowed types: int, float, str, bool.
+        Types should be passed as string.
+        Allowed types: int, float, str, bool, validation_list.
 
             Parameters:
                     setting (dict): Value of the type to convert
@@ -47,10 +48,18 @@ class SettingsManager:
             Returns:
                     value (str): the value in the specified type when type is allowed
         """
-        if setting["type"] in [int, str, float]:
-            return setting["type"](value)
-        elif setting["type"] == bool:
-            return str(value).lower() == "true"
+        _format_funcs = {
+            "bool": lambda x: str(x).lower() == "true",
+            "validation_list": lambda x: [
+                validation for validation in x.split(",") if validation
+            ],
+            "int": int,
+            "float": float,
+            "str": str,
+        }
+        if setting["type"] in _format_funcs.keys():
+            return _format_funcs[setting["type"]](value)
+
         return value
 
     def read_value(self, name):
@@ -67,7 +76,7 @@ SETTINGS_MANAGER = SettingsManager(
     {
         "LIFEGUARD_SERVER_PORT": {
             "default": "5567",
-            "type": int,
+            "type": "int",
             "description": "Lifeguard server port number",
         },
         "LIFEGUARD_DIRECTORY": {
@@ -108,10 +117,12 @@ SETTINGS_MANAGER = SettingsManager(
         },
         "LIFEGUARD_RUN_ONLY_VALIDATIONS": {
             "default": "",
+            "type": "validation_list",
             "description": "A comma separated list with validations name to be run",
         },
         "LIFEGUARD_SKIP_VALIDATIONS": {
             "default": "",
+            "type": "validation_list",
             "description": "A comma separated list with validations name to be skipped",
         },
     }
@@ -125,16 +136,11 @@ LIFEGUARD_EMAIL_SMTP_PASSWD = SETTINGS_MANAGER.read_value("LIFEGUARD_EMAIL_SMTP_
 LIFEGUARD_EMAIL_SMTP_SERVER = SETTINGS_MANAGER.read_value("LIFEGUARD_EMAIL_SMTP_SERVER")
 LIFEGUARD_EMAIL_SMTP_PORT = SETTINGS_MANAGER.read_value("LIFEGUARD_EMAIL_SMTP_PORT")
 
-
 LOG_LEVEL = SETTINGS_MANAGER.read_value("LIFEGUARD_LOG_LEVEL")
 HTTP_PROXY = SETTINGS_MANAGER.read_value("LIFEGUARD_HTTP_PROXY")
 HTTPS_PROXY = SETTINGS_MANAGER.read_value("LIFEGUARD_HTTPS_PROXY")
 
-# TODO: changes this after #27 was done
-_validations = SETTINGS_MANAGER.read_value("LIFEGUARD_RUN_ONLY_VALIDATIONS").split(",")
-LIFEGUARD_RUN_ONLY_VALIDATIONS = [
-    validation for validation in _validations if validation
-]
-
-_validations = SETTINGS_MANAGER.read_value("LIFEGUARD_SKIP_VALIDATIONS").split(",")
-LIFEGUARD_SKIP_VALIDATIONS = [validation for validation in _validations if validation]
+LIFEGUARD_RUN_ONLY_VALIDATIONS = SETTINGS_MANAGER.read_value(
+    "LIFEGUARD_RUN_ONLY_VALIDATIONS"
+)
+LIFEGUARD_SKIP_VALIDATIONS = SETTINGS_MANAGER.read_value("LIFEGUARD_SKIP_VALIDATIONS")

--- a/lifeguard/settings.py
+++ b/lifeguard/settings.py
@@ -2,7 +2,6 @@
 Lifeguard core settings
 """
 import re
-import sys
 from os import environ
 
 
@@ -19,7 +18,10 @@ class SettingsManager(object):
 
     def __get_value(self, name):
         options = self.settings[name]
-        return environ.get(name, options["default"])
+        value = environ.get(name, options["default"])
+        if "type" in options:
+            return self.__set_type(options, value)
+        return value
 
     def __search_dynamic_attribute(self, name):
         for entry in self.settings:
@@ -27,6 +29,17 @@ class SettingsManager(object):
                 return environ.get(name, self.settings[entry]["default"])
 
         raise AttributeNotFoundInSettings("{} not found".format(name))
+
+    @staticmethod
+    def __set_type(setting, value):
+        """
+        Convert value to explict type
+        """
+        if setting["type"] in [int, str, float]:
+            return setting["type"](value)
+        elif setting["type"] == bool:
+            return str(value).lower() == "true"
+        return value
 
     def read_value(self, name):
         """
@@ -42,6 +55,7 @@ SETTINGS_MANAGER = SettingsManager(
     {
         "LIFEGUARD_SERVER_PORT": {
             "default": "5567",
+            "type": int,
             "description": "Lifeguard server port number",
         },
         "LIFEGUARD_DIRECTORY": {

--- a/lifeguard/settings.py
+++ b/lifeguard/settings.py
@@ -33,7 +33,16 @@ class SettingsManager(object):
     @staticmethod
     def __set_type(setting, value):
         """
-        Convert value to explict type
+        Convert setting value to explict type.
+        Allowed types: int, float, str, bool.
+
+
+            Parameters:
+                    setting (dict): Value of the type to convert
+                    value (object): Value to be converted
+
+            Returns:
+                    value (str): the value in the specified type when type is allowed
         """
         if setting["type"] in [int, str, float]:
             return setting["type"](value)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="lifeguard",
-    version="0.0.27",
+    version="0.0.28",
     url="https://github.com/LifeguardSystem/lifeguard",
     author="Diego Rubin",
     author_email="contact@diegorubin.dev",

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -72,7 +72,7 @@ class SettingsTest(unittest.TestCase):
         current_value = settings.read_value("LIFEGUARD_SERVER_PORT")
         self.assertEqual(current_value, "5567")
 
-    def test_get_default_value_with_bool_type_for_dynamic_attribute(self):
+    def test_get_default_value_with_declared_type_for_dynamic_attribute(self):
         settings = SettingsManager(
             {
                 "BOOL_SETTING": {

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -43,6 +43,36 @@ class SettingsTest(unittest.TestCase):
             "A comma separated list with validations name to be run",
         )
 
+    def test_get_allowed_validations_returns_1_validation(self):
+        settings = SettingsManager(
+            {
+                "LIFEGUARD_RUN_ONLY_VALIDATIONS": {
+                    "default": "validation1",
+                    "type": "validation_list",
+                    "description": "allowed validations",
+                }
+            }
+        )
+        self.assertEqual(
+            ["validation1"],
+            settings.read_value("LIFEGUARD_RUN_ONLY_VALIDATIONS"),
+        )
+
+    def test_get_allowed_validations_returns_2_validations(self):
+        settings = SettingsManager(
+            {
+                "LIFEGUARD_RUN_ONLY_VALIDATIONS": {
+                    "default": "validation1,validation2",
+                    "type": "validation_list",
+                    "description": "allowed validations",
+                }
+            }
+        )
+        self.assertEqual(
+            ["validation1", "validation2"],
+            settings.read_value("LIFEGUARD_RUN_ONLY_VALIDATIONS"),
+        )
+
     def test_lifeguard_skip_validations_default(self):
         self.assertEqual(LIFEGUARD_SKIP_VALIDATIONS, [])
         self.assertEqual(
@@ -67,7 +97,7 @@ class SettingsTest(unittest.TestCase):
             {
                 "LIFEGUARD_SERVER_PORT": {
                     "default": "5567",
-                    "type": int,
+                    "type": "int",
                     "description": "Lifeguard server port number",
                 }
             }
@@ -93,7 +123,7 @@ class SettingsTest(unittest.TestCase):
             {
                 "BOOL_SETTING": {
                     "default": "false",
-                    "type": bool,
+                    "type": "bool",
                     "description": "dynammic descritpion",
                 }
             }
@@ -126,7 +156,7 @@ class SettingsTest(unittest.TestCase):
             {
                 "DYNAMIC_TEST_ATTRIBUTE": {
                     "default": "default_value",
-                    "type": bool,
+                    "type": "bool",
                     "description": "dynammic descritpion",
                 }
             }


### PR DESCRIPTION
The type declared in settings must exist in settings dict. When the type is not explicitly declared, nothing happens to the value (it is used as it is declared - commonly as string).
Eg:
`
"LIFEGUARD_SERVER_PORT": {
     "default": "5567",
     "type": "int",
     "description": "Lifeguard server port number",
  },
 "LIFEGUARD_RUN_ONLY_VALIDATIONS": {
   "default": "",
   "type": "validation_list",
   "description": "A comma separated list with validations name to be run",
 }`

I've created unit tests and put the expected return in those names (please let me know if it's not good).

PS: I mentioned the wrong issue in some commit messages. The correct number is 27.