### PR TITLE
feat(#41)!: removing validation name from constructor

### DIFF
--- a/lifeguard/validations.py
+++ b/lifeguard/validations.py
@@ -32,13 +32,13 @@ class ValidationResponse:
     """
 
     def __init__(
-        self, validation_name, status, details, settings=None, last_execution=None
+        self, status, details, settings=None, last_execution=None, validation_name=None
     ):
-        self._validation_name = validation_name
         self._status = status
         self._details = details
         self._settings = settings
         self._last_execution = last_execution
+        self._validation_name = validation_name
 
     @property
     def validation_name(self):
@@ -74,6 +74,13 @@ class ValidationResponse:
         Return last execution
         """
         return self._last_execution
+
+    @validation_name.setter
+    def validation_name(self, value):
+        """
+        Setter for validation name
+        """
+        self._validation_name = value
 
     @last_execution.setter
     def last_execution(self, value):
@@ -166,6 +173,7 @@ def validation(
                     return None
 
                 result = decorated(*args, **kwargs)
+                result.validation_name = decorated.__name__
                 __execute_actions(actions, result, settings)
 
                 return result
@@ -179,13 +187,13 @@ def validation(
                 __execute_actions(
                     actions_on_error,
                     ValidationResponse(
-                        decorated.__name__,
                         PROBLEM,
                         {
                             "exception": str(exception),
                             "traceback": traceback.format_exc(),
                             "use_error_template": True,
                         },
+                        validation_name=decorated.__name__,
                     ),
                     settings,
                 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="lifeguard",
-    version="0.0.48",
+    version="1.0.0",
     url="https://github.com/LifeguardSystem/lifeguard",
     author="Diego Rubin",
     author_email="contact@diegorubin.dev",

--- a/tests/fixtures/validations/simple_validation.py
+++ b/tests/fixtures/validations/simple_validation.py
@@ -4,4 +4,4 @@ from lifeguard.validations import ValidationResponse, validation
 
 @validation(description="simple description", actions=[], settings={})
 def simple_validation():
-    return ValidationResponse("simple_validation", NORMAL, {})
+    return ValidationResponse(NORMAL, {})

--- a/tests/fixtures/validations/simple_with_action_validation.py
+++ b/tests/fixtures/validations/simple_with_action_validation.py
@@ -8,4 +8,4 @@ def simple_action(_response, _settings):
 
 @validation(description="simple description", actions=[simple_action], settings={})
 def simple_with_action_validation():
-    return ValidationResponse("simple_with_action_validation", NORMAL, {})
+    return ValidationResponse(NORMAL, {})

--- a/tests/fixtures/validations/simple_with_invalid_action_validation.py
+++ b/tests/fixtures/validations/simple_with_invalid_action_validation.py
@@ -8,4 +8,4 @@ def invalid_action():
 
 @validation(description="simple description", actions=[invalid_action])
 def simple_with_invalid_action_validation():
-    return ValidationResponse("simple_with_invalid_action_validation", NORMAL, {})
+    return ValidationResponse(NORMAL, {})

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -12,7 +12,7 @@ from lifeguard.server import (
 from lifeguard.validations import ValidationResponse
 
 test_validation = MagicMock(name="test_validation")
-test_validation.return_value = ValidationResponse("test_validation", NORMAL, {})
+test_validation.return_value = ValidationResponse(NORMAL, {})
 
 VALIDATIONS = {"test_validation": {"ref": test_validation}}
 
@@ -56,7 +56,7 @@ class TestServer(unittest.TestCase):
         mock_repository_instance = MagicMock(name="mock_repository_instance")
         mock_validation_repository.return_value = mock_repository_instance
         mock_repository_instance.fetch_last_validation_result.return_value = (
-            ValidationResponse("test_validation", NORMAL, {})
+            ValidationResponse(NORMAL, {})
         )
 
         response = get_validation("test_validation")
@@ -71,7 +71,7 @@ class TestServer(unittest.TestCase):
         mock_repository_instance = MagicMock(name="mock_repository_instance")
         mock_validation_repository.return_value = mock_repository_instance
         mock_repository_instance.fetch_all_validation_results.return_value = [
-            ValidationResponse("test_validation", PROBLEM, {})
+            ValidationResponse(PROBLEM, {}, validation_name="test_validation")
         ]
 
         response = get_status()
@@ -91,7 +91,7 @@ class TestServer(unittest.TestCase):
         mock_repository_instance = MagicMock(name="mock_repository_instance")
         mock_validation_repository.return_value = mock_repository_instance
         mock_repository_instance.fetch_all_validation_results.return_value = [
-            ValidationResponse("test_validation", NORMAL, {})
+            ValidationResponse(NORMAL, {})
         ]
 
         response = get_status()
@@ -107,7 +107,7 @@ class TestServer(unittest.TestCase):
         mock_repository_instance = MagicMock(name="mock_repository_instance")
         mock_validation_repository.return_value = mock_repository_instance
         mock_repository_instance.fetch_all_validation_results.return_value = [
-            ValidationResponse("test_validation", NORMAL, {})
+            ValidationResponse(NORMAL, {}, validation_name="test_validation")
         ]
 
         response = get_status_complete()

--- a/tests/test_validations.py
+++ b/tests/test_validations.py
@@ -19,7 +19,7 @@ class TestValidationResponse(unittest.TestCase):
         details = {}
         settings = {}
 
-        response = ValidationResponse("name", NORMAL, details, settings)
+        response = ValidationResponse(NORMAL, details, settings, validation_name="name")
 
         self.assertEqual(response.validation_name, "name")
         self.assertEqual(response.status, "NORMAL")
@@ -27,7 +27,7 @@ class TestValidationResponse(unittest.TestCase):
         self.assertEqual(response.settings, settings)
 
     def test_validation_response_to_str(self):
-        response = ValidationResponse("name", NORMAL, {}, {})
+        response = ValidationResponse(NORMAL, {}, {}, validation_name="name")
         self.assertEqual(
             str(response),
             "{'validation_name': 'name', 'status': 'NORMAL', 'details': {}, 'settings': {}}",


### PR DESCRIPTION
BREAKING CHANGE: validation name in the ValidationResponse on constructor it is no longer necessary and will be settled in the decorator.